### PR TITLE
誤字によるFontAwesomeインポートエラーを修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,9 +16,9 @@
 
  @import "bootstrap/scss/bootstrap";
 
- $fa-font-path: '@fortawesome/fortawesome-free/webfonts';
- @import "@fortawesome/fortawesome-free/scss/fortawesome";
- @import "@fortawesome/fortawesome-free/scss/regular";
+ $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
+ @import "@fortawesome/fontawesome-free/scss/fontawesome";
+ @import "@fortawesome/fontawesome-free/scss/regular";
 
  div.field_with_errors {
    display: contents;


### PR DESCRIPTION
## 概要

- FontAwesomeをインポートする記述の誤字を修正

### 内容

- `application.scss`の FontAwesome をインポートする記述の誤字を修正した